### PR TITLE
Fix download [QS-400]

### DIFF
--- a/01-Login/package-lock.json
+++ b/01-Login/package-lock.json
@@ -5966,9 +5966,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6240,9 +6240,9 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -11102,16 +11102,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/01-Login/src/app/services/auth.service.ts
+++ b/01-Login/src/app/services/auth.service.ts
@@ -73,10 +73,10 @@ export class AuthService {
 
     this.safariViewController.isAvailable()
       .then((available: boolean) => {
-        const domain = AUTH_CONFIG.domain;
+        const auth0Domain = AUTH_CONFIG.domain;
         const clientId = AUTH_CONFIG.clientId;
         const pkgId = AUTH_CONFIG.packageIdentifier;
-        let url = `https://${domain}/v2/logout?client_id=${clientId}&returnTo=${pkgId}://${domain}/cordova/${pkgId}/callback`;
+        let url = `https://${auth0Domain}/v2/logout?client_id=${clientId}&returnTo=${pkgId}://${auth0Domain}/cordova/${pkgId}/callback`;
         if (available) {
           this.safariViewController.show({
             url: url


### PR DESCRIPTION
When downloading the sample from [docs](https://auth0.com/docs/quickstart/native/ionic4) using the download button, all the occurrences of `{domain}` will be replaced with your tenant.
In the [logout](https://github.com/auth0-samples/auth0-ionic4-samples/blob/f738d246827329dbd83211d072ad8050ecac2023/01-Login/src/app/services/auth.service.ts#L66-L97) method, the logout URL is assigned to a variable like:

https://github.com/auth0-samples/auth0-ionic4-samples/blob/f738d246827329dbd83211d072ad8050ecac2023/01-Login/src/app/services/auth.service.ts#L76-L79

If the sample is downloaded from docs, the `url` variable will end up like:
```js
let url = `https://$tenant.auth0.com/v2/logout?client_id=${clientId}&returnTo=${pkgId}://$tenant.auth0.com/cordova/${pkgId}/callback`;
```
When this line should be as it is, without replacing `{domain}`.

Rename const [`domain`](https://github.com/auth0-samples/auth0-ionic4-samples/blob/f738d246827329dbd83211d072ad8050ecac2023/01-Login/src/app/services/auth.service.ts#L76) other than `domain` It'll fix the issue.

Fixes #2.