### PR TITLE
Close Logout Window after Logout

### DIFF
--- a/01-Login/src/app/app.component.ts
+++ b/01-Login/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { Platform } from '@ionic/angular';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
+import { AuthService } from './services/auth.service';
 
 // Import Auth0Cordova
 import Auth0Cordova from '@auth0/cordova';
@@ -13,6 +14,7 @@ import Auth0Cordova from '@auth0/cordova';
 })
 export class AppComponent {
   constructor(
+    private auth: AuthService,
     private platform: Platform,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar
@@ -27,6 +29,7 @@ export class AppComponent {
 
       // Redirect back to app after authenticating
       (window as any).handleOpenURL = (url: string) => {
+        this.auth.safariViewController.hide();
         Auth0Cordova.onRedirectUri(url);
       }
     });

--- a/01-Login/src/app/app.component.ts
+++ b/01-Login/src/app/app.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { Platform } from '@ionic/angular';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
-import { AuthService } from './services/auth.service';
 
 // Import Auth0Cordova
 import Auth0Cordova from '@auth0/cordova';
@@ -14,7 +13,6 @@ import Auth0Cordova from '@auth0/cordova';
 })
 export class AppComponent {
   constructor(
-    private auth: AuthService,
     private platform: Platform,
     private splashScreen: SplashScreen,
     private statusBar: StatusBar
@@ -29,7 +27,6 @@ export class AppComponent {
 
       // Redirect back to app after authenticating
       (window as any).handleOpenURL = (url: string) => {
-        this.auth.safariViewController.hide();
         Auth0Cordova.onRedirectUri(url);
       }
     });

--- a/01-Login/src/app/services/auth.service.ts
+++ b/01-Login/src/app/services/auth.service.ts
@@ -20,8 +20,8 @@ export class AuthService {
 
   constructor(
     public zone: NgZone,
-    public safariViewController: SafariViewController,
     private storage: Storage,
+    private safariViewController: SafariViewController
   ) {
     this.storage.get('profile').then(user => this.user = user);
     this.storage.get('access_token').then(token => this.accessToken = token);
@@ -64,13 +64,9 @@ export class AuthService {
   }
 
   logout() {
-    this.storage.remove('profile');
-    this.storage.remove('access_token');
-    this.storage.remove('expires_at');
     this.accessToken = null;
     this.user = null;
     this.loggedIn = false;
-
     this.safariViewController.isAvailable()
       .then((available: boolean) => {
         const auth0Domain = AUTH_CONFIG.domain;
@@ -83,8 +79,15 @@ export class AuthService {
           })
           .subscribe((result: any) => {
               if(result.event === 'opened') console.log('Opened');
-              else if(result.event === 'loaded') console.log('Loaded');
               else if(result.event === 'closed') console.log('Closed');
+
+              if (result.event === 'loaded') {
+                console.log('Loaded');
+                this.storage.remove('profile');
+                this.storage.remove('access_token');
+                this.storage.remove('expires_at');
+                this.safariViewController.hide();
+              }
             },
             (error: any) => console.error(error)
           );

--- a/01-Login/src/app/services/auth.service.ts
+++ b/01-Login/src/app/services/auth.service.ts
@@ -20,8 +20,8 @@ export class AuthService {
 
   constructor(
     public zone: NgZone,
+    public safariViewController: SafariViewController,
     private storage: Storage,
-    private safariViewController: SafariViewController
   ) {
     this.storage.get('profile').then(user => this.user = user);
     this.storage.get('access_token').then(token => this.accessToken = token);


### PR DESCRIPTION
Currently when logging out, there is an issue where the window doesn't automatically close.  This PR moves the in app browser window close to the `handleOpenUrl` handler that handles urls registered with the `cordova-plugin-customurlscheme` package.  This will trigger when the callback route is hit after logout. 

Resolves https://github.com/auth0-samples/auth0-ionic4-samples/issues/5